### PR TITLE
fix: Removed problematic localised name code for hidden recipes that …

### DIFF
--- a/prototypes/updates/generate-void-crushing-recipes.lua
+++ b/prototypes/updates/generate-void-crushing-recipes.lua
@@ -17,10 +17,10 @@ for _, item in pairs(flib_prototypes.all("item")) do
       {
         type = "recipe",
         name = "kr-crush-" .. item.name,
-        localised_name = {
-          "recipe-name.kr-crush",
-          flib_locale.of(item),
-        },
+        -- localised_name = {
+        --   "recipe-name.kr-crush",
+        --   flib_locale.of_item(item),
+        -- },
         icon = "__Krastorio2Assets__/icons/recipes/trash.png",
         category = "kr-void-crushing",
         hidden = true,


### PR DESCRIPTION
…don't need a localised name. Intended to fix compatibility with Muluna.

In response to https://github.com/Polka37/Krastorio2-Spaced-Out/issues/2