### PR TITLE
Fix recycler not outputting holmium-ore by increasing result_inventory_size

### DIFF
--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -81,3 +81,12 @@ for type_name in pairs(defines.prototypes.item) do
 end
 
 data.raw.quality.normal.hidden = false
+
+--The code below had been made by Johannes2070
+--Fix: Ensure the recycler has enough result inventory slots to handle all recycling outputs.
+local recycler = data.raw["furnace"]["recycler"]
+if recycler then
+  if recycler.result_inventory_size < 13 then
+    recycler.result_inventory_size = 13
+  end
+end


### PR DESCRIPTION
This pull request addresses an issue where the recycler machine would fail to output more than 12 different item types during certain recycling recipes (e.g., scrap-recycling).

Changes made:

Set recycler.result_inventory_size = 13 in data-final-fixes.lua to ensure all expected items can be output.

Included a safeguard to only apply the change if the current inventory size is smaller.

Reason:
Some recycling recipes produce more than 12 unique results with probabilities. Factorio silently truncates extra outputs if the result inventory is too small, causing items like holmium-ore.

Note:
This fix is placed in data-final-fixes.lua to ensure compatibility with other mods that may modify the recycler earlier.