### PR TITLE
Temp FIX for scrap-recycling for Flugora 

### DIFF
--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -45,6 +45,114 @@ if recycler then
   end
 end
 
+-- Create or fix scrap-recycling recipe for Factoriopedia visibility
+if data.raw.item["scrap"] then
+  -- First check if the recipe already exists
+  if not data.raw.recipe["scrap-recycling"] then
+    -- Create the recipe if it doesn't exist
+    data:extend({
+      {
+        type = "recipe",
+        name = "scrap-recycling",
+        localised_name = {"recipe-name.recycling", {"item-name.scrap"}},
+        category = "recycling",
+        subgroup = "other",
+        order = "z[scrap-recycling]",
+        hidden = false,
+        hidden_in_factoriopedia = false,
+        hide_from_player_crafting = true,
+        enabled = false,
+        allow_decomposition = false,
+        unlock_results = false,
+        energy_required = 0.5 / 16,
+        ingredients = {
+          {type = "item", name = "scrap", amount = 1}
+        },
+        results = {
+          {type = "item", name = "iron-gear-wheel",        amount = 1, probability = 0.20, show_details_in_recipe_tooltip = false},
+          {type = "item", name = "electronic-circuit",     amount = 1, probability = 0.10, show_details_in_recipe_tooltip = false},
+          {type = "item", name = "solid-fuel",             amount = 1, probability = 0.07, show_details_in_recipe_tooltip = false},
+          {type = "item", name = "concrete",               amount = 1, probability = 0.06, show_details_in_recipe_tooltip = false},
+          {type = "item", name = "ice",                    amount = 1, probability = 0.05, show_details_in_recipe_tooltip = false},
+          {type = "item", name = "steel-plate",            amount = 1, probability = 0.04, show_details_in_recipe_tooltip = false},
+          {type = "item", name = "battery",                amount = 1, probability = 0.04, show_details_in_recipe_tooltip = false},
+          {type = "item", name = "stone",                  amount = 1, probability = 0.04, show_details_in_recipe_tooltip = false},
+          {type = "item", name = "advanced-circuit",       amount = 1, probability = 0.03, show_details_in_recipe_tooltip = false},
+          {type = "item", name = "copper-cable",           amount = 1, probability = 0.03, show_details_in_recipe_tooltip = false},
+          {type = "item", name = "processing-unit",        amount = 1, probability = 0.02, show_details_in_recipe_tooltip = false},
+          {type = "item", name = "low-density-structure",  amount = 1, probability = 0.01, show_details_in_recipe_tooltip = false},
+          {type = "item", name = "holmium-ore",            amount = 1, probability = 0.01, show_details_in_recipe_tooltip = false},
+        },
+        icons = {
+          {
+            icon = "__quality__/graphics/icons/recycling.png",
+            icon_size = 64
+          },
+          {
+            icon = "__space-age__/graphics/icons/scrap.png",
+            icon_size = 64,
+            scale = 0.4
+          },
+          {
+            icon = "__quality__/graphics/icons/recycling-top.png",
+            icon_size = 64
+          }
+        }
+      }
+    })
+  else
+    -- If the recipe exists, ensure all properties are set correctly
+    local recipe = data.raw.recipe["scrap-recycling"]
+    recipe.hidden = false
+    recipe.hidden_in_factoriopedia = false
+    recipe.hide_from_player_crafting = true
+    recipe.enabled = false
+    recipe.category = "recycling"
+    recipe.subgroup = "other"
+    recipe.order = "z[scrap-recycling]"
+    recipe.energy_required = 0.5 / 16
+    recipe.allow_decomposition = false
+    recipe.unlock_results = false
+    recipe.localised_name = {"recipe-name.recycling", {"item-name.scrap"}}
+    
+    recipe.ingredients = {
+      {type = "item", name = "scrap", amount = 1}
+    }
+    
+    recipe.results = {
+      {type = "item", name = "iron-gear-wheel",        amount = 1, probability = 0.20, show_details_in_recipe_tooltip = false},
+      {type = "item", name = "electronic-circuit",     amount = 1, probability = 0.10, show_details_in_recipe_tooltip = false},
+      {type = "item", name = "solid-fuel",             amount = 1, probability = 0.07, show_details_in_recipe_tooltip = false},
+      {type = "item", name = "concrete",               amount = 1, probability = 0.06, show_details_in_recipe_tooltip = false},
+      {type = "item", name = "ice",                    amount = 1, probability = 0.05, show_details_in_recipe_tooltip = false},
+      {type = "item", name = "steel-plate",            amount = 1, probability = 0.04, show_details_in_recipe_tooltip = false},
+      {type = "item", name = "battery",                amount = 1, probability = 0.04, show_details_in_recipe_tooltip = false},
+      {type = "item", name = "stone",                  amount = 1, probability = 0.04, show_details_in_recipe_tooltip = false},
+      {type = "item", name = "advanced-circuit",       amount = 1, probability = 0.03, show_details_in_recipe_tooltip = false},
+      {type = "item", name = "copper-cable",           amount = 1, probability = 0.03, show_details_in_recipe_tooltip = false},
+      {type = "item", name = "processing-unit",        amount = 1, probability = 0.02, show_details_in_recipe_tooltip = false},
+      {type = "item", name = "low-density-structure",  amount = 1, probability = 0.01, show_details_in_recipe_tooltip = false},
+      {type = "item", name = "holmium-ore",            amount = 1, probability = 0.01, show_details_in_recipe_tooltip = false},
+    }
+    
+    recipe.icons = {
+      {
+        icon = "__quality__/graphics/icons/recycling.png",
+        icon_size = 64
+      },
+      {
+        icon = "__space-age__/graphics/icons/scrap.png",
+        icon_size = 64,
+        scale = 0.4
+      },
+      {
+        icon = "__quality__/graphics/icons/recycling-top.png",
+        icon_size = 64
+      }
+    }
+  end
+end
+
 if settings.startup["kr-steel-pipes-need-pumps"].value then
   return
 end

--- a/prototypes/updates/base/recipes.lua
+++ b/prototypes/updates/base/recipes.lua
@@ -715,21 +715,24 @@ data_util.add_or_replace_ingredient( "casting-steel", "molten-iron", { type = "f
 data_util.add_or_replace_ingredient( "casting-low-density-structure", "molten-iron", { type = "fluid", name = "molten-iron", amount = 60 } )
 data_util.add_or_replace_ingredient( "casting-low-density-structure", "molten-copper", { type = "fluid", name = "molten-copper", amount = 120 } )
 
-data.raw.recipe["scrap-recycling"].results = {
-      {type = "item", name = "iron-gear-wheel",        amount = 1, probability = 0.20, show_details_in_recipe_tooltip = false},
-      {type = "item", name = "electronic-circuit",     amount = 1, probability = 0.10, show_details_in_recipe_tooltip = false},
-      {type = "item", name = "solid-fuel",             amount = 1, probability = 0.07, show_details_in_recipe_tooltip = false},
-      {type = "item", name = "concrete",               amount = 1, probability = 0.06, show_details_in_recipe_tooltip = false},
-      {type = "item", name = "ice",                    amount = 1, probability = 0.05, show_details_in_recipe_tooltip = false},
-      {type = "item", name = "steel-plate",            amount = 1, probability = 0.04, show_details_in_recipe_tooltip = false},
-      {type = "item", name = "battery",                amount = 1, probability = 0.04, show_details_in_recipe_tooltip = false},
-      {type = "item", name = "stone",                  amount = 1, probability = 0.04, show_details_in_recipe_tooltip = false},
-      {type = "item", name = "advanced-circuit",       amount = 1, probability = 0.03, show_details_in_recipe_tooltip = false},
-      {type = "item", name = "copper-cable",           amount = 1, probability = 0.03, show_details_in_recipe_tooltip = false},
-      {type = "item", name = "processing-unit",        amount = 1, probability = 0.02, show_details_in_recipe_tooltip = false},
-      {type = "item", name = "low-density-structure",  amount = 1, probability = 0.01, show_details_in_recipe_tooltip = false},
-      {type = "item", name = "holmium-ore",            amount = 1, probability = 0.01, show_details_in_recipe_tooltip = false},
-}
+-- Update scrap-recycling recipe results with Krastorio items
+if data.raw.recipe["scrap-recycling"] then
+  data.raw.recipe["scrap-recycling"].results = {
+        {type = "item", name = "iron-gear-wheel",        amount = 1, probability = 0.20, show_details_in_recipe_tooltip = false},
+        {type = "item", name = "electronic-circuit",     amount = 1, probability = 0.10, show_details_in_recipe_tooltip = false},
+        {type = "item", name = "solid-fuel",             amount = 1, probability = 0.07, show_details_in_recipe_tooltip = false},
+        {type = "item", name = "concrete",               amount = 1, probability = 0.06, show_details_in_recipe_tooltip = false},
+        {type = "item", name = "ice",                    amount = 1, probability = 0.05, show_details_in_recipe_tooltip = false},
+        {type = "item", name = "steel-plate",            amount = 1, probability = 0.04, show_details_in_recipe_tooltip = false},
+        {type = "item", name = "battery",                amount = 1, probability = 0.04, show_details_in_recipe_tooltip = false},
+        {type = "item", name = "stone",                  amount = 1, probability = 0.04, show_details_in_recipe_tooltip = false},
+        {type = "item", name = "advanced-circuit",       amount = 1, probability = 0.03, show_details_in_recipe_tooltip = false},
+        {type = "item", name = "copper-cable",           amount = 1, probability = 0.03, show_details_in_recipe_tooltip = false},
+        {type = "item", name = "processing-unit",        amount = 1, probability = 0.02, show_details_in_recipe_tooltip = false},
+        {type = "item", name = "low-density-structure",  amount = 1, probability = 0.01, show_details_in_recipe_tooltip = false},
+        {type = "item", name = "holmium-ore",            amount = 1, probability = 0.01, show_details_in_recipe_tooltip = false},
+  }
+end
 
 -- Science packs
 

--- a/prototypes/updates/base/technologies.lua
+++ b/prototypes/updates/base/technologies.lua
@@ -233,3 +233,24 @@ data_util.set_icon(data.raw.technology["steel-processing"], "__Krastorio2Assets_
 data_util.set_icon(data.raw.technology["utility-science-pack"], "__Krastorio2Assets__/technologies/utility-tech-card.png", 256)
 -- stylua: ignore end
 
+-- Ensure scrap-recycling recipe is unlocked by recycling technology
+if data.raw.technology["recycling"] then
+  -- Add scrap-recycling to the recycling technology if it's not already there
+  local has_scrap_recycling = false
+  if data.raw.technology["recycling"].effects then
+    for _, effect in pairs(data.raw.technology["recycling"].effects) do
+      if effect.type == "unlock-recipe" and effect.recipe == "scrap-recycling" then
+        has_scrap_recycling = true
+        break
+      end
+    end
+  end
+  
+  if not has_scrap_recycling then
+    table.insert(data.raw.technology["recycling"].effects, {
+      type = "unlock-recipe",
+      recipe = "scrap-recycling"
+    })
+  end
+end
+


### PR DESCRIPTION
…nology

moved scrap-recycling to data-final-fixes.lua
This is temp fix for now
This pull request introduces a new `scrap-recycling` recipe and integrates it into the game mechanics, ensuring compatibility with existing features and mods. The changes primarily focus on adding the recipe, updating its properties, and linking it to relevant technologies.

### Additions and Updates to the `scrap-recycling` Recipe:
* Created a new `scrap-recycling` recipe if it does not already exist. The recipe processes `scrap` into various items with specific probabilities and includes custom icons. If the recipe already exists, its properties are updated to ensure consistency. (`data-final-fixes.lua`, [data-final-fixes.luaR48-R155](diffhunk://#diff-9aada42649a310285f1e8e128a6cc56cbfa7ccecee5a43cc6b19ee55a6eeac41R48-R155))
* Updated the `scrap-recycling` recipe results to include Krastorio-specific items, ensuring compatibility with the Krastorio mod. (`prototypes/updates/base/recipes.lua`, [[1]](diffhunk://#diff-727ae4af2b4cddb796b9023b035ae7c031e0642affedeeabcf9cedc8bbac5337R718-R719) [[2]](diffhunk://#diff-727ae4af2b4cddb796b9023b035ae7c031e0642affedeeabcf9cedc8bbac5337R735)

### Integration with Technology:
* Ensured the `scrap-recycling` recipe is unlocked by the `recycling` technology, adding it to the technology's effects if not already present. (`prototypes/updates/base/technologies.lua`, [prototypes/updates/base/technologies.luaR236-R256](diffhunk://#diff-d9bc5d5cf86bc639b3e9f5241c8ccbb4bb46bf84bbe0e44ee1a94fef7fe6c2b6R236-R256))