### PR TITLE
Update recipes.lua

### DIFF
--- a/prototypes/updates/base/recipes.lua
+++ b/prototypes/updates/base/recipes.lua
@@ -399,8 +399,6 @@ data_util.add_or_replace_ingredient(
 )
 table.insert(data.raw.recipe["nuclear-reactor"].ingredients, { type = "item", name = "kr-rare-metals", amount = 200 })
 
-data.raw.recipe["offshore-pump"].enabled = false
-
 data_util.add_or_replace_ingredient("oil-refinery", "steel-plate", { type = "item", name = "kr-steel-beam", amount = 4 })
 data_util.convert_ingredient("oil-refinery", "iron-gear-wheel", "kr-steel-gear-wheel")
 


### PR DESCRIPTION
As of 2.0, offshore pump is unlocked by the steam power trigger technology, and disabled by default. This line is redundant.