### PR TITLE
fix: Fix zh-CN locale typo

### DIFF
--- a/locale/zh-CN/Krastorio2.cfg
+++ b/locale/zh-CN/Krastorio2.cfg
@@ -31,9 +31,9 @@ kr-railgun-shell=磁轨炮弹
 kr-turret-missile=炮塔导弹
 
 [autoplace-control-names]
-kr-imersite=__ITEM__kr-imersite__
-kr-mineral-water=矿物质水
-kr-rare-metal-ore=__ITEM__kr-rare-metal-ore__
+kr-imersite=__ENTITY__kr-imersite__
+kr-mineral-water=__ENTITY__kr-mineral-water__
+kr-rare-metal-ore=__ENTITY__kr-rare-metal-ore__
 
 [command-help]
 kr-give-patreon-items=- 在Patreon上支持K2将提供奖励物品。
@@ -150,6 +150,7 @@ kr-turret-remnant=炮塔（残骸）
 kr-virus-cloud=病毒云
 kr-warehouse=仓库
 kr-wind-turbine=风力涡轮机
+fusion-reactor=冷聚变反应堆
 
 [entity-description]
 kr-advanced-assembling-machine=更快的组装机，具备将矿石处理为中间体的先进工艺。
@@ -166,7 +167,7 @@ kr-crusher=把放进去的物品粉碎。有些物品将返回原料，但多数
 kr-electrolysis-plant=在液体中通电以产生化学反应。
 kr-filtration-plant=通过液体过滤掉一些物质。
 kr-flare-stack=燃烧任意流体。此过程将释放大量污染，并可能产生副产品。
-kr-fusion-reactor=通过[item=dt-fuel]氘氚燃料电池中的原子聚变产生大量能量。一台聚变反应堆可支持20台高级涡轮机。
+kr-fusion-reactor=通过[item=kr-dt-fuel-cell]氘氚燃料电池中的原子聚变产生大量能量。一台聚变反应堆可支持20台高级涡轮机。
 kr-gas-power-station=燃烧液体来产生能量。效率低下，但很简单！
 kr-greenhouse=种植可收获的木材与用于装饰和修复的植物。
 kr-legacy-steel-pipe-to-ground=这个实体是用来帮助将2.0版本以前的存档正常迁移的。移除了它你就放不回来了！
@@ -180,7 +181,7 @@ kr-shelter=为您的阵营设置出生点。每个阵营在每个星球表面上
 kr-stabilizer-charging-station=为物质稳定剂充能。
 kr-steel-pipe=支持更大压力的管道。
 kr-steel-pipe-to-ground=支持更大压力的地下管道。
-kr-tesla-coil=将为装有[item=energy-absorber]的任何设备充电。两座塔不能放置太近！
+kr-tesla-coil=将为装有[item=kr-energy-absorber-equipment]的任何设备充电。两座塔不能放置太近！
 kr-wind-turbine=从风力中获取些微能量。
 
 [entity-status]
@@ -241,6 +242,7 @@ kr-mineral-water=矿物质水
 kr-nitric-acid=硝酸
 kr-nitrogen=氮气
 kr-oxygen=氧气
+kr-molten-rare-metals=熔融稀有金属
 
 [fuel-category-name]
 kr-antimatter-fuel=反物质燃料
@@ -341,8 +343,18 @@ kr-lithium-sulfur-battery=锂硫电池
 kr-loader=装卸机
 kr-matter-cube=物质方块
 kr-matter-research-data=物质研究数据
+kr-electromagnetic-research-data=电磁研究数据
+kr-metallurgic-research-data=冶金研究数据
+kr-agricultural-research-data=农业研究数据
+kr-cryogenic-research-data=低温研究数据
+kr-promethium-research-data=钷研究数据
 kr-matter-stabilizer=物质稳定器
 kr-matter-tech-card=物质科技卡
+kr-electromagnetic-tech-card=电磁科技卡
+kr-metallurgic-tech-card=冶金科技卡
+kr-agricultural-tech-card=农业科技卡
+kr-cryogenic-tech-card=低温科技卡
+kr-promethium-tech-card=钷科技卡
 kr-note-1=神秘笔记
 kr-nuclear-artillery-shell=核重炮炮弹
 kr-nuclear-turret-rocket=核炮塔火箭弹
@@ -375,6 +387,9 @@ optimization-tech-card=优化科技卡
 pistol-magazine=手枪弹匣
 production-tech-card=生产科技卡
 utility-tech-card=效能科技卡
+kr-gamma-core=伽马核心
+kr-beta-core=贝塔核心
+kr-alpha-core=阿尔法核心
 
 [item-description]
 kr-accelerator=一份来自您朋友的礼物。这支步枪能加速子弹，造成更大伤害。
@@ -391,8 +406,13 @@ kr-note-1=真的吗？您大老远跑来就是为了这？您花了很长时间�
 kr-poop=咦呃，真恶心！
 kr-potato=一个大号土豆！它似乎可以食用，但也许可以发射到某个地方？
 kr-spoiled-potato=它变质了，闻起来非常恶臭。
-kr-teleportation-gps-module=将行星传送器与GPS导航卫星[item=gps-satellite]连接。
+kr-teleportation-gps-module=将行星传送器与GPS导航卫星[item=kr-gps-satellite]连接。
 optimization-tech-card=通过处理太空研究数据获得。
+agricultural-science-pack=总是以 100% 新鲜度制作
+kr-gamma-core=专门用于研究的亚人类智能
+kr-beta-core=专门用于研究的一般人类智能
+kr-alpha-core=专门用于研究的超人类智能
+
 
 [item-group-name]
 kr-smelting-crafting=冶炼工艺
@@ -443,6 +463,7 @@ kr-main-menu-song=启用Krastorio 2主菜单主题
 kr-realistic-weapons-auto-aim=真实武器：自动瞄准
 kr-realistic-weapons=真实武器
 kr-shelter-tint=庇护所颜色
+kr-steel-pipes-need-pumps=钢制管道需要泵才能连接储罐
 
 [mod-setting-description]
 kr-containers=添加中型和大型存储容器。禁用可使用其他模组的容器（例如：AAI容器）。
@@ -477,12 +498,12 @@ kr-easy-imersium-gear-wheel=简易紫晶齿轮
 kr-easy-steel-beam=简易钢梁
 kr-easy-steel-gear-wheel=简易钢齿轮
 kr-electronic-components-with-lithium=锂电子元件
-kr-enriched-copper=__ITEM__enriched-copper__
-kr-enriched-iron=__ITEM__enriched-iron__
-kr-enriched-rare-metals=__ITEM__enriched-rare-metals__
+kr-enriched-copper=__ITEM__kr-enriched-copper__
+kr-enriched-iron=__ITEM__kr-enriched-iron__
+kr-enriched-rare-metals=__ITEM__kr-enriched-rare-metals__
 kr-filter-copper-ore-from-dirty-water=过滤污水[item=copper-ore]
 kr-filter-iron-ore-from-dirty-water=过滤污水[item=iron-ore]
-kr-filter-rare-metal-ore-from-dirty-water=过滤污水[item=raw-rare-metals]
+kr-filter-rare-metal-ore-from-dirty-water=过滤污水[item=kr-rare-metal-ore]
 kr-fuel-from-light-oil=轻油制燃料
 kr-fuel-from-solid-fuel=固体燃料制燃料
 kr-fusion=核聚变
@@ -494,9 +515,9 @@ kr-iron-plate-from-enriched-iron=富化铁矿冶炼铁板
 kr-iron-stick-from-enriched-iron=富化铁矿冶炼铁棒
 kr-iron-stick-from-iron-ore=铁矿冶炼铁棒
 kr-landfill-with-sand=沙制填埋材料
-kr-lithium=__ITEM__lithium__
+kr-lithium=__ITEM__kr-lithium__
 kr-matter-to=从物质获得__1__
-kr-quartz=__ITEM__quartz__
+kr-quartz=__ITEM__kr-quartz__
 kr-rare-metals-from-enriched-rare-metals=富化稀有金属矿冶炼稀有金属
 kr-restore-used-pollution-filter=回收用过的污染过滤器
 kr-rocket-fuel-with-ammonia=氨制火箭燃料
@@ -507,6 +528,35 @@ kr-water-from-atmosphere=__FLUID__water__
 kr-water-separation=水分离
 kr-wood-with-fertilizer=肥料培养木材
 wood=木材
+kr-coke-carbon=从碳制作焦炭
+molten-enriched-copper=富化铜矿熔炼
+molten-enriched-iron=富化铁矿熔炼
+kr-carbide-processing-circuit=碳化物处理单元
+kr-bio-processing-circuit=生物处理单元
+kr-ammonia=氨气
+casting=铸造
+kr-biter-biomass=从虫族卵制作生物质
+lithium=锂
+kr-high-fusion=高温聚变
+kr-fusion-overdrive=超频聚变反应堆
+kr-fusion-underdrive=降频聚变反应堆
+kr-cooling=带冷却
+kr-spoilage-decomposition=腐化物堆肥
+kr-molten-rare-metals-from-lava=从熔岩制作熔融稀有金属
+kr-molten-rare-metals=稀有金属矿石熔炼
+kr-molten-enriched-rare-metals=富集稀有金属熔炼
+kr-casting-rare-metals=铸造稀有金属
+kr-gamma-core=伽马核心
+kr-beta-core=贝塔核心
+kr-alpha-core=阿尔法核心
+kr-electronic-circuit-wood=木制电子电路
+
+[recipe-description]
+kr-fusion=普通聚变设置。总输出 1.5 GW，效率 75%
+kr-high-fusion=燃料电池生产的突破允许难以想象的能量生产规模。总输出 3.5 GW，效率 87.5%
+kr-fusion-overdrive=超频聚变反应堆。总输出 2.5 GW，效率 50%
+kr-fusion-underdrive=降频聚变反应堆。总输出 0.5 GW，效率 100%
+kr-spoilage-decomposition=使用生物流体作为催化剂从腐化物中提取生物甲醇
 
 [shortcut-name]
 kr-jackhammer=__ITEM__kr-jackhammer__
@@ -516,20 +566,21 @@ kr-black-reinforced-plate=__ITEM__kr-black-reinforced-plate__
 kr-white-reinforced-plate=__ITEM__kr-white-reinforced-plate__
 
 [technology-name]
+fusion-reactor=冷聚变反应堆
 automation-science-pack=__ITEM__automation-tech-card__
 kr-advanced-additional-engine-equipment=高级附加电动机模块
 kr-advanced-chemical-plant=__ENTITY__kr-advanced-chemical-plant__
 kr-advanced-chemistry=高级化学
 kr-advanced-exoskeleton-equipment=高级外骨骼模块
-kr-advanced-fuel=__ITEM__advanced-fuel__
+kr-advanced-fuel=__ITEM__kr-advanced-fuel__
 kr-advanced-furnace=__ENTITY__kr-advanced-furnace__
 kr-advanced-lab=高级研究室
 kr-advanced-pickaxe=高级铁镐
-kr-advanced-radar=高级雷达
+kr-advanced-radar=__ENTITY__kr-advanced-radar__
 kr-advanced-roboports=高级机器人指令平台
 kr-advanced-solar-panel=__ENTITY__kr-advanced-solar-panel__
 kr-advanced-tank=__ENTITY__kr-advanced-tank__
-kr-advanced-tech-card=__ITEM__advanced-tech-card__
+kr-advanced-tech-card=__ITEM__kr-advanced-tech-card__
 kr-advanced-turrets=高级炮塔
 kr-ai-core=AI核心
 kr-air-purification=空气净化
@@ -538,7 +589,7 @@ kr-antimatter-reactor=__ENTITY__kr-antimatter-reactor__
 kr-antimatter-reactor-equipment=便携式反物质聚变反应堆模块
 kr-atmosphere-condensation=大气冷凝
 kr-automation=高级组装机
-kr-automation-core=__ITEM__automation-core__
+kr-automation-core=__ITEM__kr-automation-core__
 kr-battery-mk3-equipment=电池组模块 MK3
 kr-bio-fuel=生物燃料
 kr-bio-processing=生物处理
@@ -548,7 +599,7 @@ kr-crusher=__ENTITY__kr-crusher__
 kr-decorations=欢迎来到丛林
 kr-electric-mining-drill-mk2=__ENTITY__kr-electric-mining-drill-mk2__
 kr-electric-mining-drill-mk3=__ENTITY__kr-electric-mining-drill-mk3__
-kr-energy-control-unit=__ITEM__energy-control-unit__
+kr-energy-control-unit=__ITEM__kr-energy-control-unit__
 kr-energy-shield-mk3-equipment=充能护盾 MK3
 kr-energy-shield-mk4-equipment=充能护盾 MK4
 kr-energy-storage=__ENTITY__kr-energy-storage__
@@ -567,23 +618,31 @@ kr-laboratory=研究中心
 kr-laser-artillery-turret=__ENTITY__kr-laser-artillery-turret__
 kr-light-armor=__ITEM__light-armor__
 kr-lithium-processing=锂处理
-kr-lithium-sulfur-battery=__ITEM__lithium-sulfur-battery__
+kr-lithium-sulfur-battery=__ITEM__kr-lithium-sulfur-battery__
 kr-logistic-containers-1=更大物流容器
 kr-logistic-containers-2=物流系统的更大容器
 kr-logistic=物流学
 kr-logo=__ENTITY__kr-logo__
 kr-matter-coal-processing=煤转化
 kr-matter-copper-processing=铜转化
-kr-matter-cube=__ITEM__matter-cube__
+kr-matter-cube=__ITEM__kr-matter-cube__
 kr-matter-iron-processing=铁转化
 kr-matter-minerals-processing=矿物转化
 kr-matter-oil-processing=原油转化
 kr-matter-processing=物质处理
 kr-matter-rare-metals-processing=稀有金属转化
 kr-matter-stone-processing=石头转化
-kr-matter-tech-card=__ITEM__matter-tech-card__
+kr-matter-tech-card=__ITEM__kr-matter-tech-card__
 kr-matter-uranium-processing=铀转化
 kr-matter-water-processing=水转化
+kr-matter-ice-processing=冰转化
+kr-matter-carbon-processing=碳转化
+kr-matter-calcite-processing=方解石转化
+kr-matter-tungsten-processing=钨转化
+kr-matter-holmium-processing=钬转化
+kr-matter-lithium-brine-processing=锂盐水转化
+kr-matter-fluorine-processing=氟转化
+kr-matter-scrap-processing=废料转化
 kr-military=军事学
 kr-mineral-water-gathering=提取矿物质水
 kr-nuclear-locomotive=核能机车
@@ -593,8 +652,8 @@ kr-personal-laser-defense-mk3-equipment=激光防御模块 MK3
 kr-personal-laser-defense-mk4-equipment=激光防御模块 MK4
 kr-planetary-teleporter=__ENTITY__kr-planetary-teleporter__
 kr-portable-generator-equipment=发电机模块
-kr-power-armor-mk3=__ITEM__power-armor-mk3__
-kr-power-armor-mk4=__ITEM__power-armor-mk4__
+kr-power-armor-mk3=__ITEM__kr-power-armor-mk3__
+kr-power-armor-mk4=__ITEM__kr-power-armor-mk4__
 kr-quantum-computer=__ENTITY__kr-quantum-computer__
 kr-quarry-minerals-extraction=紫晶开采
 kr-radar=雷达
@@ -609,7 +668,7 @@ kr-shelter=__ENTITY__kr-shelter__
 kr-silicon-processing=硅处理
 kr-singularity-beacon=__ENTITY__kr-singularity-beacon__
 kr-singularity-lab=__ENTITY__kr-singularity-lab__
-kr-singularity-tech-card=__ITEM__singularity-tech-card__
+kr-singularity-tech-card=__ITEM__kr-singularity-tech-card__
 kr-steel-fluid-handling=钢制流体处理
 kr-steel-fluid-tanks=钢制储液罐
 kr-stone-processing=石矿处理
@@ -618,6 +677,11 @@ kr-superior-inserters=超级机械臂
 kr-superior-night-vision-equipment=超级夜视模块
 kr-superior-solar-panel-equipment=超市太阳能模块
 kr-tesla-coil=特斯拉线圈塔
+kr-molten-rare-metals=熔融稀有金属利用
+kr-gleba-greenhouse=格莱巴温室
+kr-gamma-core=伽马核心
+kr-beta-core=贝塔核心
+kr-alpha-core=阿尔法核心
 
 [technology-description]
 automation-science-pack=随着自动化核心的突破，许多以前的手工流程都有可能实现自动化。
@@ -711,6 +775,10 @@ kr-superior-solar-panel-equipment=为您的载具和设备提供功率更高的�
 kr-tesla-coil=允许将电力无线传输到设备插槽中。
 optimization-tech-card=在微重力环境下进行的实验会产生极其有用的数据，对地面科技大有裨益。
 rocket-silo=能够把自己推进轨道的极其复杂的机器。可承担微重力实验。
+kr-gleba-greenhouse=适应温室在格莱巴种植尤马科和果冻坚果
+kr-gamma-core=专门用于研究的亚人类智能
+kr-beta-core=专门用于研究的一般人类智能
+kr-alpha-core=专门用于研究的超人类智能
 
 [virtual-signal-name]
 kr-attention-1=注意 1

--- a/locale/zh-CN/Krastorio2Compatibility.cfg
+++ b/locale/zh-CN/Krastorio2Compatibility.cfg
@@ -21,6 +21,7 @@ se-material-tech-card=材料学科技卡
 
 [recipe-name]
 kr-electronic-components=__ITEM__crushed-rare-metals__
+sand=__ITEM__kr-sand__
 
 [technology-name]
 kr-matter-chromium-processing=铬转化
@@ -29,6 +30,7 @@ kr-matter-lead-processing=铅转化
 kr-matter-nickel-processing=镍转化
 kr-matter-tellurium-processing=碲转化
 kr-matter-tin-processing=锡转化
+kr-automation-core=__ITEM__kr-automation-core__
 
 [bvs-categories]
 intergalactic-communication=星际通信


### PR DESCRIPTION
Compared with the latest English locale, the missing fields and some errors in zh-CN have been added and corrected.