### PR TITLE
fix: Fix kr-big-roboport's big border between the edge of the tile and the edge of the building

### DIFF
--- a/prototypes/buildings/big-roboport.lua
+++ b/prototypes/buildings/big-roboport.lua
@@ -34,7 +34,7 @@ data:extend({
     flags = { "placeable-neutral", "placeable-player", "player-creation" },
     minable = { mining_time = 1, result = "kr-big-roboport" },
     heating_energy = "300kW",
-    collision_box = { { -3.75, -3.38 }, { 3.99, 3.75 } },
+    collision_box = { { -3.9, -3.9 }, { 3.9, 3.9 } },
     selection_box = { { -4, -4 }, { 4, 4 } },
     logistics_radius = 100,
     construction_radius = 200,


### PR DESCRIPTION
fix kr-big-roboport's big border between the edge of the tile and the edge of the building where enugh to place a medium-electric-pole that can not be selected.  I followed the offical advice "it is customary to leave 0.1 wide...... , lets the player move between the building and electric poles/inserters etc".