### PR TITLE
Showing more alternative recipes as signals and fixing some recipe orders so the base recipes may be set via signalling. Fix for #112

### DIFF
--- a/prototypes/recipes/electronics.lua
+++ b/prototypes/recipes/electronics.lua
@@ -3,6 +3,7 @@ data:extend({
 		type = "recipe",
 		name = "kr-bio-processing-circuit",
 		enabled = false,
+		order = "b[circuits]-c[processing-circuit-bio]",
 		icons = {
 			{ icon = "__base__/graphics/icons/processing-unit.png" },
 			{ icon = "__space-age__/graphics/icons/pentapod-egg.png", scale = 0.26, shift = { -8, -8 } },

--- a/prototypes/recipes/metallurgy.lua
+++ b/prototypes/recipes/metallurgy.lua
@@ -156,6 +156,7 @@ data:extend({
 			{ icon = "__Krastorio2Assets__/icons/items/iron-beam.png" },
 			{ icon = "__space-age__/graphics/icons/fluid/molten-iron.png", scale = 0.33, shift = { 8, -8 } },
 		},
+		hide_from_signal_gui = false,
 		enabled = false,
 		ingredients = {
 			{ type = "fluid", name = "molten-iron", amount = 20, fluidbox_multiplier = 10 },
@@ -176,6 +177,7 @@ data:extend({
 			{ icon = "__Krastorio2Assets__/icons/items/steel-beam.png" },
 			{ icon = "__space-age__/graphics/icons/fluid/molten-iron.png", scale = 0.33, shift = { 8, -8 } },
 		},
+		hide_from_signal_gui = false,
 		enabled = false,
 		ingredients = {
 			{ type = "fluid", name = "molten-iron", amount = 40, fluidbox_multiplier = 10 },
@@ -196,6 +198,7 @@ data:extend({
 			{ icon = "__Krastorio2Assets__/icons/items/steel-gear-wheel.png" },
 			{ icon = "__space-age__/graphics/icons/fluid/molten-iron.png", scale = 0.33, shift = { 8, -8 } },
 		},
+		hide_from_signal_gui = false,
 		enabled = false,
 		ingredients = {
 			{ type = "fluid", name = "molten-iron", amount = 20, fluidbox_multiplier = 10 },
@@ -216,6 +219,7 @@ data:extend({
 			{ icon = "__Krastorio2Assets__/icons/entities/steel-pipe.png", scale = 0.5, shift = { -8, 8 } },
 			{ icon = "__space-age__/graphics/icons/fluid/molten-iron.png", scale = 0.5, shift = { 8, -8 } },
 		},
+		hide_from_signal_gui = false,
 		enabled = false,
 		ingredients = {
 			{ type = "fluid", name = "molten-iron", amount = 20, fluidbox_multiplier = 10 },
@@ -236,6 +240,7 @@ data:extend({
 			{ icon = "__Krastorio2Assets__/icons/entities/steel-pipe-to-ground.png", scale = 0.5, shift = { -8, 8 } },
 			{ icon = "__space-age__/graphics/icons/fluid/molten-iron.png", scale = 0.5, shift = { 8, -8 } },
 		},
+		hide_from_signal_gui = false,
 		enabled = false,
 		ingredients = {
 			{ type = "item", name = "kr-steel-pipe", amount = 10, fluidbox_multiplier = 10 },
@@ -279,6 +284,7 @@ data:extend({
 			{ icon = "__Krastorio2Assets__/icons/items/imersium-plate.png" },
 			{ icon = "__k2so-assets__/icons/fluids/molten-rare-metals.png", scale = 0.33, shift = { 8, -8 } },
 		},
+		hide_from_signal_gui = false,
 		enabled = false,
 		energy_required = 32,
 		ingredients = {
@@ -300,6 +306,7 @@ data:extend({
 			{ icon = "__Krastorio2Assets__/icons/items/imersium-beam.png" },
 			{ icon = "__k2so-assets__/icons/fluids/molten-rare-metals.png", scale = 0.33, shift = { 8, -8 } },
 		},
+		hide_from_signal_gui = false,
 		enabled = false,
 		energy_required = 12,
 		ingredients = {
@@ -321,6 +328,7 @@ data:extend({
 			{ icon = "__Krastorio2Assets__/icons/items/imersium-gear-wheel.png" },
 			{ icon = "__k2so-assets__/icons/fluids/molten-rare-metals.png", scale = 0.33, shift = { 8, -8 } },
 		},
+		hide_from_signal_gui = false,
 		enabled = false,
 		energy_required = 2,
 		ingredients = {

--- a/prototypes/recipes/smelting.lua
+++ b/prototypes/recipes/smelting.lua
@@ -36,6 +36,7 @@ data:extend({
 			{ type = "item", name = "kr-coke", amount = 6 },
 		},
 		allow_productivity = true,
+		hide_from_signal_gui = false,
 	},
 	{
 		type = "recipe",

--- a/prototypes/updates/base/recipes.lua
+++ b/prototypes/updates/base/recipes.lua
@@ -157,6 +157,9 @@ data_util.add_or_replace_ingredient(
 recipe["electronic-circuit"].results = {
 	{ type = "item", name = "electronic-circuit", amount = 2 },
 }
+recipe["electronic-circuit"].order = "b[circuits]-a[electronic-circuit-original]"
+
+recipe["processing-unit"].order = "b[circuits]-c[processing-circuit-a]"
 
 data_util.add_or_replace_ingredient(
 	"energy-shield-mk2-equipment",
@@ -718,10 +721,12 @@ recipe["casting-steel"].icons = {
 	{ icon = "__Krastorio2Assets__/icons/items/steel-plate.png" },
 	{ icon = "__space-age__/graphics/icons/fluid/molten-iron.png", scale = 0.33, shift = { 8, -8 } },
 }
+recipe["casting-steel"].hide_from_signal_gui = false
 recipe["casting-iron-gear-wheel"].icons = {
 	{ icon = "__Krastorio2Assets__/icons/items/iron-gear-wheel.png" },
 	{ icon = "__space-age__/graphics/icons/fluid/molten-iron.png", scale = 0.33, shift = { 8, -8 } },
 }
+recipe["casting-iron-gear-wheel"].hide_from_signal_gui = false
 
 data_util.add_or_replace_ingredient(
 	"casting-iron-gear-wheel",


### PR DESCRIPTION
Fix missing casting signals from signal selector GUI (mainly so they can be used to set recipes on advanced furnance that is differentiate from its base recipes), updated orders of bio processing unit and wood electric circuits so they have lower priority than the base recipe and may be selected with set recipe signals.

Resolves #112 