### PR TITLE
Fix #133, avoid assignment when `gleba_stone` doesn't exist

### DIFF
--- a/prototypes/updates/base/resources.lua
+++ b/prototypes/updates/base/resources.lua
@@ -22,6 +22,10 @@ increase_base_density("coal", 2)
 increase_base_density("copper-ore", 1.5)
 
 if data.raw["planet"]["gleba"].map_gen_settings then
-	data.raw["planet"]["gleba"].map_gen_settings.autoplace_controls["gleba_stone"] =
-		{ size = 3, frequency = 1.5, richness = 2 }
+	if not data.raw["planet"]["gleba"].map_gen_settings.autoplace_controls["gleba_stone"] then
+		data_util.error("Map gen setting gleba_stone does not exist.")
+	else
+		data.raw["planet"]["gleba"].map_gen_settings.autoplace_controls["gleba_stone"] =
+			{ size = 3, frequency = 1.5, richness = 2 }
+	end
 end


### PR DESCRIPTION
If `gleba_stone` doesn't exist in `map_gen_settings` for Gleba write an error message to the log and avoid crashing.