### PR TITLE
Fix: Update item and fluid names in technology research triggers

### DIFF
--- a/prototypes/final-fixes/enforce-k2-items.lua
+++ b/prototypes/final-fixes/enforce-k2-items.lua
@@ -69,3 +69,14 @@ for _, ore in pairs(data.raw.resource) do
 		end
 	end
 end
+
+for _, tech in pairs(data.raw.technology) do
+	if tech.research_trigger then
+		if tech.research_trigger.item and convert[tech.research_trigger.item] then
+			tech.research_trigger.item = "kr-" .. tech.research_trigger.item
+		end
+		if tech.research_trigger.fluid and convert[tech.research_trigger.fluid] then
+			tech.research_trigger.fluid = "kr-" .. tech.research_trigger.fluid
+		end
+	end
+end


### PR DESCRIPTION
## Description
This PR fixes an issue where technologies added by other mods become impossible to unlock because their `research_trigger` requires items or fluids that K2SO has removed/hidden (e.g., `sand`, `glass`, `silicon`).

## Problem
In `enforce-k2-items.lua`, base items like `sand` and `glass` are correctly replaced with `kr-sand`, `kr-glass`, etc., across all recipes, tiles, and minable resources. However, the script did not iterate over `data.raw.technology`. 
If another mod (such as `skewer_planet_vesta`) sets a technology trigger to craft `sand` (`{ type = "craft-item", item = "sand" }`), the player can never unlock it because original base items are no longer craftable.

## Solution
Added a loop at the end of `enforce-k2-items.lua` to process `data.raw.technology`. It checks `tech.research_trigger` and automatically replaces `item` and `fluid` names with their `kr-` prefixed versions if they are present in the `convert` table.
